### PR TITLE
Ranking

### DIFF
--- a/webapp/go/isuports.go
+++ b/webapp/go/isuports.go
@@ -1557,7 +1557,10 @@ func competitionRankingHandler(c echo.Context) error {
 		return err
 	}
 
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		now := time.Now().Unix()
 		if _, err := adminDB.ExecContext(
 			ctx,
@@ -1581,6 +1584,8 @@ func competitionRankingHandler(c echo.Context) error {
 	}
 
 	pagedRanks := getPagedRanks(v.tenantID, competition.ID, rankAfter)
+
+	wg.Wait()
 
 	res := SuccessResult{
 		Status: true,


### PR DESCRIPTION
visit_history への挿入を別ゴルーチンで実行させる
もう MySQL を別サーバに移すか、visit_history をインメモリで管理するかしか改善の余地はなさそう